### PR TITLE
CASMUSER-2645 fix license field in spec file

### DIFF
--- a/cray-uai-util.spec
+++ b/cray-uai-util.spec
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020-2022] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,7 @@
 Requires: craycli
 
 Name: cray-%{packagename}
-License: Cray Software License Agreement
+License: MIT License
 Summary: %{packagename}
 Version: %(cat .version)
 Release: %(echo ${BUILD_METADATA})


### PR DESCRIPTION
## Summary and Scope

Fix "License" field in spec-file.  Should have been 'MIT License' was the Cray license.

Backward compatible fix -- no content change

## Issues and Related PRs

* Resolves [2645](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2645)

## Testing

Tested by building and verifying that a valid RPM was produced.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks for this change.


## Pull Request Checklist

- [ N/A ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

