### PR TITLE
Build RPM as nooarch and noos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-08-08
+- Build RPM as `noarch` and `noos`
+
 ## [2.1.0] - 2021-12-7
 - CASMUSER-2809: Add support for auto delete timeouts
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -32,8 +32,8 @@ pipeline {
         stage('Publish') {
             steps {
                 script {
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: env.IS_STABLE)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", arch: "noarch", os: "noos", isStable: env.IS_STABLE)
+                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", os: "noos", isStable: env.IS_STABLE)
                 }
             }
         }

--- a/cray-uai-util.spec
+++ b/cray-uai-util.spec
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright [2020-2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020-2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,7 @@ Summary: %{packagename}
 Version: %(cat .version)
 Release: %(echo ${BUILD_METADATA})
 Source: %{name}-%{version}.tar.bz2
+BuildArchitectures: noarch
 Vendor: Cray Inc.
 Group: Productivity/Clustering/Computing
 


### PR DESCRIPTION
Due to recent changes to csm-config, only zypper repos for `noos` and for the specific sles 15 SP version will be available on nodes. This means that all packages for the nodes must be in the appropriate zypper repository. This RPM is currently only building for SLES 15 SP2 and for x86_64. It has no dependencies which require that, so the simplest solution which requires the least maintenance in the future is moving this to build its RPM as `noos` and `noarch`. This is what is being done in all repos where it is possible.